### PR TITLE
Update to gitignore to allow for _Local folder

### DIFF
--- a/DDD/.gitignore
+++ b/DDD/.gitignore
@@ -76,4 +76,3 @@ DerivedDataCache/*
 # Starter Content
 */StarterContent
 */_StarterContent
-*/_Local

--- a/DDD/Content/_Local/.gitignore
+++ b/DDD/Content/_Local/.gitignore
@@ -1,0 +1,5 @@
+# Local folder
+*
+
+# Include .gitignore
+!.gitignore


### PR DESCRIPTION
Anything placed inside the _Local folder will not be added to the repo. It is useful for temporary actors, testing levels, etc.