### PR TITLE
bugfix/jb/uproject-file-plugins

### DIFF
--- a/DDD/DDD.uproject
+++ b/DDD/DDD.uproject
@@ -16,7 +16,26 @@
 			"Enabled": true
 		},
 		{
+			"Name": "TDxUnrealEditor",
+			"Enabled": true
+		},
+		{
+			"Name": "VisualStudioTools",
+			"Enabled": true,
+			"SupportedTargetPlatforms": [
+				"Win64"
+			]
+		},
+		{
 			"Name": "PCG",
+			"Enabled": true
+		},
+		{
+			"Name": "FMODStudio",
+			"Enabled": true
+		},
+		{
+			"Name": "FMODStudioNiagara",
 			"Enabled": true
 		}
 	]


### PR DESCRIPTION
fixed the uproject file to list the plugins. it appears to have been erroneously modified in the fmod update. it now has enable the plugins we had before, as well as the two fmod plugins.